### PR TITLE
added support for claims request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,34 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
-.idea
+
+##############################
+## Maven
+##############################
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+pom.xml.bak
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+##############################
+## IntelliJ
+##############################
+out/
+.idea/
+.idea_modules/
+*.iml
+*.ipr
+*.iws
+.editorconfig
+
+##############################
+## OS X
+##############################
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
-            <version>0.9.3</version>
+            <version>0.9.6</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2023 Curity AB
+  ~ Copyright 2024 Curity AB
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/CallbackRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/CallbackRequestHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Curity AB
+ * Copyright 2024 Curity AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/CallbackRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/CallbackRequestHandler.kt
@@ -101,7 +101,7 @@ class CallbackRequestHandler(
         val tokenResponse = _config.getHttpClient()
             .request(_providerConfiguration.tokenEndpoint)
             .contentType(ContentType.X_WWW_FORM_URLENCODED.contentType)
-            .body(HttpRequest.createFormUrlEncodedBodyProcessor(createPostData(requestModel.code, redirectUri)))
+            .body(HttpRequest.createFormUrlEncodedBodyProcessor(requestModel.code?.let { createPostData(it, redirectUri) }))
             .post()
             .response()
 

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/CallbackRequestModel.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/CallbackRequestModel.kt
@@ -22,7 +22,7 @@ class CallbackRequestModel(request: Request)
 {
     val error: String? = request.getQueryParameterValueOrError("error", invalidParameter)
     val errorDescription: String? = request.getQueryParameterValueOrError("error_description", invalidParameter)
-    val code: String = request.getQueryParameterValueOrError("code", invalidParameter)
+    val code: String? = request.getQueryParameterValueOrError("code", invalidParameter)
     val state: String = request.getQueryParameterValueOrError("state", invalidParameter)
 
     fun isError() = error != null|| errorDescription != null
@@ -30,6 +30,6 @@ class CallbackRequestModel(request: Request)
     companion object
     {
         private val invalidParameter = { s: String -> RuntimeException(String.format(
-                "Expected only one query string parameter named %s, but found multiple.", s)) }
+            "Expected only one query string parameter named %s, but found multiple.", s)) }
     }
 }

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/CallbackRequestModel.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/CallbackRequestModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Curity AB
+ * Copyright 2024 Curity AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,6 @@ class CallbackRequestModel(request: Request)
     companion object
     {
         private val invalidParameter = { s: String -> RuntimeException(String.format(
-            "Expected only one query string parameter named %s, but found multiple.", s)) }
+                "Expected only one query string parameter named %s, but found multiple.", s)) }
     }
 }

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/OidcClaimSupportAuthenticatorRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/OidcClaimSupportAuthenticatorRequestHandler.kt
@@ -50,7 +50,8 @@ class OidcClaimSupportAuthenticatorRequestHandler(private val _config: OidcClaim
             }
         }
 
-        _config.getSessionManager().put(Attribute.of("state", state))
+
+        val claims = _config.getClaims().orElse(null)
 
         val queryStringArguments = linkedMapOf<String, Collection<String>>(
             "client_id" to setOf(_config.getClientId()),
@@ -58,7 +59,11 @@ class OidcClaimSupportAuthenticatorRequestHandler(private val _config: OidcClaim
             "state" to setOf(state),
             "response_type" to setOf("code"),
             "scope" to setOf(scope.joinToString(" "))
-        )
+        ).apply {
+            claims?.let { put("claims", setOf(it))}
+        }
+
+        _config.getSessionManager().put(Attribute.of("state", state))
 
         _logger.debug("Redirecting to {} with query string arguments {}", _providerConfig.authorizeEndpoint,
             queryStringArguments

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/OidcClaimSupportAuthenticatorRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/OidcClaimSupportAuthenticatorRequestHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Curity AB
+ * Copyright 2024 Curity AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,6 @@ class OidcClaimSupportAuthenticatorRequestHandler(private val _config: OidcClaim
                 add("openid")
             }
         }
-
 
         val claims = _config.getClaims().orElse(null)
 

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/ProviderConfigurationManagedObject.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/ProviderConfigurationManagedObject.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Curity AB
+ * Copyright 2024 Curity AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/ProviderConfigurationManagedObject.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/ProviderConfigurationManagedObject.kt
@@ -87,7 +87,6 @@ class ProviderConfigurationManagedObject(private val _config: OidcClaimsSupportA
             .setRequireExpirationTime()
             .setSkipDefaultAudienceValidation()
             .setExpectedIssuer(_config.getIssuer())
-            .setRelaxVerificationKeyValidation()
             .setVerificationKeyResolver(HttpsJwksVerificationKeyResolver(httpsJwks))
             .build()
     }

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/RedirectUriUtil.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/RedirectUriUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Curity AB
+ * Copyright 2024 Curity AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/config/OidcClaimsSupportAuthenticatorPluginConfig.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/config/OidcClaimsSupportAuthenticatorPluginConfig.kt
@@ -25,6 +25,7 @@ import se.curity.identityserver.sdk.service.HttpClient
 import se.curity.identityserver.sdk.service.Json
 import se.curity.identityserver.sdk.service.SessionManager
 import se.curity.identityserver.sdk.service.authentication.AuthenticatorInformationProvider
+import java.util.Optional
 
 interface OidcClaimsSupportAuthenticatorPluginConfig : Configuration {
     @Description("Client id")
@@ -39,6 +40,9 @@ interface OidcClaimsSupportAuthenticatorPluginConfig : Configuration {
     @Description("The HTTP client with any proxy and TLS settings that will be used to connect to the provider")
     @DefaultService
     fun getHttpClient(): HttpClient
+
+    @Description("The claims that are returned at the userinfo endpoint and in the ID token")
+    fun getClaims(): Optional<String>
 
     fun getSessionManager(): SessionManager
 

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/config/OidcClaimsSupportAuthenticatorPluginConfig.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/config/OidcClaimsSupportAuthenticatorPluginConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Curity AB
+ * Copyright 2024 Curity AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/descriptor/OidcClaimsSupportAuthenticatorPluginDescriptor.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/descriptor/OidcClaimsSupportAuthenticatorPluginDescriptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Curity AB
+ * Copyright 2024 Curity AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- adds support for request of additional user claims that are returned at the userinfo endpoint and in the ID token.
- Upgraded `org.bitbucket.b_c:jose4j` to `0.9.6`  since the current used version `0.9.3` was vulnerable with a HIGH severity [CVE](https://devhub.checkmarx.com/cve-details/CVE-2023-51775/ ) . Didn't spent time on figuring out if the plugin was vulnerable due to this but just upgraded to the latest safe version as a good measure.